### PR TITLE
Allow raml lint checker to accept handlers without raml if their name…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+## [7.1.2] - 2020-10-09
+### Changed
+- Raml-lint-checker will now allow handler methods whose names are not specified in the
+raml file if the handler name starts with 'administration'
+- Updated framework-libraries to version 7.1.2
 
 ## [7.1.1] - 2020-09-25
 ### Changed

--- a/framework-generators/rest-adapter-core/src/main/java/uk/gov/justice/services/adapter/rest/administration/Naming.java
+++ b/framework-generators/rest-adapter-core/src/main/java/uk/gov/justice/services/adapter/rest/administration/Naming.java
@@ -1,0 +1,6 @@
+package uk.gov.justice.services.adapter.rest.administration;
+
+public interface Naming {
+
+    String ADMINISTRATION_NAMING_PREFIX = "administration";
+}

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
     <properties>
         <cpp.repo.name>microservice_framework</cpp.repo.name>
-        <framework-libraries.version>7.1.1</framework-libraries.version>
+        <framework-libraries.version>7.1.2</framework-libraries.version>
     </properties>
 
     <dependencyManagement>

--- a/raml-lint-check/lint-check-rules/src/main/java/uk/gov/justice/raml/maven/lintchecker/rules/utils/HandlerScanner.java
+++ b/raml-lint-check/lint-check-rules/src/main/java/uk/gov/justice/raml/maven/lintchecker/rules/utils/HandlerScanner.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.raml.maven.lintchecker.rules.utils;
 
 import static java.util.stream.Collectors.toList;
+import static uk.gov.justice.services.adapter.rest.administration.Naming.ADMINISTRATION_NAMING_PREFIX;
 
 import uk.gov.justice.raml.maven.lintchecker.LintCheckPluginException;
 import uk.gov.justice.services.core.annotation.CustomServiceComponent;
@@ -41,8 +42,13 @@ public class HandlerScanner {
                 .getMethodsAnnotatedWith(Handles.class)
                 .stream()
                 .filter(this::isServiceComponent)
+                .filter(this::isNotAdministrationHandler)
                 .map(this::actionName)
                 .collect(toList());
+    }
+
+    private boolean isNotAdministrationHandler(final Method method) {
+        return ! method.getAnnotation(Handles.class).value().startsWith(ADMINISTRATION_NAMING_PREFIX);
     }
 
     private String actionName(final Method method) {


### PR DESCRIPTION
… starts with 'administration'