### PR TITLE
commits from release-17.x.x branch: For EVENT_PROCESSORs, derive the destinationType (queue|topic) from e…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 [Semantic Versioning](http://semver.org/).
 
 [Unreleased]
-
 ## [17.6.9] - 2024-10-11
 ### Fixed
 - Fixed spelling mistake in OversizeMessageGuard error message
@@ -45,6 +44,15 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 - Update framework libraries to 17.6.2 in order to:
   - Update jobstore to process tasks with higher priority first
   - Fix for Jackson single argument constructor issue inspired from  https://github.com/FasterXML/jackson-databind/issues/1498
+
+## [17.5.7] - 2024-08-12
+- For EVENT_PROCESSORs, derive the destinationType (queue|topic) from event_sources.location.jms_uri in event-sources.yaml when RAML is used for the EVENT_PROCESSOR
+
+## [17.5.6] - 2024-08-06
+- For EVENT_PROCESSORs, derive the destinationType (queue|topic) from event_sources.location.jms_uri in event-sources.yaml when YAML is  used for the EVENT_PROCESSOR
+
+## [17.5.5] - 2024-07-23
+- PEG-347: Jacksons SingleArgumentConstructor fix
 
 ## [17.6.1] - 2024-07-12
 ### Changed

--- a/framework-generators/generators-subscription/src/main/java/uk/gov/justice/services/generators/subscription/parser/EventSourcesFileParserFactory.java
+++ b/framework-generators/generators-subscription/src/main/java/uk/gov/justice/services/generators/subscription/parser/EventSourcesFileParserFactory.java
@@ -1,0 +1,33 @@
+package uk.gov.justice.services.generators.subscription.parser;
+
+import uk.gov.justice.services.common.converter.jackson.ObjectMapperProducer;
+import uk.gov.justice.services.generators.commons.helper.PathToUrlResolver;
+import uk.gov.justice.services.yaml.YamlFileValidator;
+import uk.gov.justice.services.yaml.YamlParser;
+import uk.gov.justice.services.yaml.YamlSchemaLoader;
+import uk.gov.justice.services.yaml.YamlToJsonObjectConverter;
+import uk.gov.justice.subscription.EventSourcesParser;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * A factory class for creating EventSourcesFileParser
+ */
+public class EventSourcesFileParserFactory {
+
+    public EventSourcesFileParser create() {
+
+        final YamlParser yamlParser = new YamlParser();
+        final YamlSchemaLoader yamlSchemaLoader = new YamlSchemaLoader();
+        final ObjectMapper objectMapper = new ObjectMapperProducer().objectMapper();
+        final YamlFileValidator yamlFileValidator = new YamlFileValidator(new YamlToJsonObjectConverter(yamlParser, objectMapper), yamlSchemaLoader);
+
+        final EventSourcesParser eventSourcesParser = new EventSourcesParser(yamlParser, yamlFileValidator);
+        final PathToUrlResolver pathToUrlResolver = new PathToUrlResolver();
+        final EventSourceYamlClasspathFinder eventSourceYamlClasspathFinder = new EventSourceYamlClasspathFinder();
+
+        final EventSourcesFileParser eventSourcesFileParser = new EventSourcesFileParser(eventSourcesParser, pathToUrlResolver, eventSourceYamlClasspathFinder);
+
+        return eventSourcesFileParser;
+    }
+}

--- a/framework-generators/generators-subscription/src/test/java/uk/gov/justice/services/generators/subscription/parser/EventSourcesFileParserFactoryTest.java
+++ b/framework-generators/generators-subscription/src/test/java/uk/gov/justice/services/generators/subscription/parser/EventSourcesFileParserFactoryTest.java
@@ -1,0 +1,21 @@
+package uk.gov.justice.services.generators.subscription.parser;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.jupiter.api.Assertions.*;
+
+import uk.gov.justice.maven.generator.io.files.parser.FileParser;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+class EventSourcesFileParserFactoryTest {
+
+    @Test
+    void create() {
+        final EventSourcesFileParser parser = new EventSourcesFileParserFactory().create();
+        assertThat(parser, is(notNullValue()));
+    }
+}

--- a/framework-generators/messaging-adapter-generator/src/main/java/uk/gov/justice/raml/jms/core/EventSourcesDestinationTypeFinder.java
+++ b/framework-generators/messaging-adapter-generator/src/main/java/uk/gov/justice/raml/jms/core/EventSourcesDestinationTypeFinder.java
@@ -1,0 +1,107 @@
+package uk.gov.justice.raml.jms.core;
+
+import static java.util.Optional.empty;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import uk.gov.justice.services.generators.subscription.parser.EventSourcesFileParser;
+import uk.gov.justice.services.generators.subscription.parser.EventSourcesFileParserFactory;
+import uk.gov.justice.services.generators.subscription.parser.JmsUriToDestinationConverter;
+import uk.gov.justice.subscription.domain.eventsource.EventSourceDefinition;
+import uk.gov.justice.subscription.jms.core.JmsUriToDestinationTypeConverter;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.jms.Destination;
+
+import org.slf4j.Logger;
+
+/**
+ * In the past, when processing raml files for generating MDBs, the envent-sources.yaml files where jms_uri are defined were ignored.
+ * This class is allowing to read any event-sources.yaml files in the classpath and trying to find the corresponding jms_uri
+ * that is used to determine whether we are dealing with a topic or a queue.
+ * Note that this is only used for event-processors only
+ */
+public class EventSourcesDestinationTypeFinder {
+
+    private final Logger logger;
+    private final JmsUriToDestinationTypeConverter uriToDestinationTypeConverter;
+    private final JmsUriToDestinationConverter jmsUriToDestinationConverter;
+    private final EventSourcesFileParserFactory eventSourceYamlParserFactory;
+
+    EventSourcesDestinationTypeFinder(JmsUriToDestinationTypeConverter uriToDestinationTypeConverter,
+                                      JmsUriToDestinationConverter jmsUriToDestinationConverter,
+                                      EventSourcesFileParserFactory eventSourceYamlParserFactory,
+                                      final Logger logger) {
+
+        this.uriToDestinationTypeConverter = uriToDestinationTypeConverter;
+        this.jmsUriToDestinationConverter = jmsUriToDestinationConverter;
+        this.eventSourceYamlParserFactory = eventSourceYamlParserFactory;
+        this.logger = logger;
+    }
+
+    /**
+     * @param serviceComponent EVENT_PROCESSOR, etc
+     * @param destinationName  the matching destination name
+     * @return Queue, Topic or empty
+     */
+    public Optional<Class<? extends Destination>> findForEventProcessor(final String serviceComponent, final String destinationName) {
+
+        try {
+
+            if (isBlank(destinationName) || !uriToDestinationTypeConverter.isEventProcessor(serviceComponent)) {
+                return empty();
+            }
+
+            final EventSourcesFileParser eventSourcesFileParser = eventSourceYamlParserFactory.create();
+            final ArrayList<Path> list = new ArrayList<>();
+            final List<EventSourceDefinition> eventSourceDefinitionList = eventSourcesFileParser.getEventSourceDefinitions(Path.of(""), list);
+            if (eventSourceDefinitionList == null) {
+                return empty();
+            }
+
+            final List<String> foundUris = eventSourceDefinitionList.stream().map(eventSourceDefinition -> eventSourceDefinition.getLocation().getJmsUri()).
+                    filter(jmsUri -> destinationName.equalsIgnoreCase(uriToDestination(jmsUri))).toList();
+
+            if (foundUris.isEmpty()) {
+                return empty();
+            }
+
+            final Set<Optional<Class<? extends Destination>>> destinations = foundUris.stream().
+                    map(uri -> uriToDestinationTypeConverter.convertForEventProcessor(serviceComponent, uri)).
+                    filter(destinationType -> destinationType.isPresent()).
+                    collect(Collectors.toSet());
+
+            if (destinations.isEmpty()) {
+                return empty();
+            }
+
+            if (destinations.size() > 1) {
+                return empty();
+            }
+
+            final Optional<Class<? extends Destination>> finalDestination = destinations.stream().
+                    findFirst().
+                    get();
+
+            return finalDestination;
+
+        } catch (Exception e) {
+            logger.warn("Failed in findForEventProcessor: {}", e.getMessage());
+            return empty();
+        }
+
+    }
+
+    private String uriToDestination(final String jmsUri) {
+        try {
+            return jmsUriToDestinationConverter.convert(jmsUri);
+        } catch (Exception e) {
+            return "";
+        }
+    }
+}

--- a/framework-generators/messaging-adapter-generator/src/main/java/uk/gov/justice/raml/jms/core/EventSourcesDestinationTypeFinderFactory.java
+++ b/framework-generators/messaging-adapter-generator/src/main/java/uk/gov/justice/raml/jms/core/EventSourcesDestinationTypeFinderFactory.java
@@ -1,0 +1,20 @@
+package uk.gov.justice.raml.jms.core;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import uk.gov.justice.services.generators.subscription.parser.EventSourcesFileParserFactory;
+import uk.gov.justice.services.generators.subscription.parser.JmsUriToDestinationConverter;
+import uk.gov.justice.subscription.jms.core.JmsUriToDestinationTypeConverter;
+
+
+public class EventSourcesDestinationTypeFinderFactory {
+
+    public EventSourcesDestinationTypeFinder create() {
+        return new EventSourcesDestinationTypeFinder(
+                new JmsUriToDestinationTypeConverter(),
+                new JmsUriToDestinationConverter(),
+                new EventSourcesFileParserFactory(),
+                getLogger(EventSourcesDestinationTypeFinder.class)
+        );
+    }
+}

--- a/framework-generators/messaging-adapter-generator/src/main/java/uk/gov/justice/subscription/jms/core/JmsUriToDestinationTypeConverter.java
+++ b/framework-generators/messaging-adapter-generator/src/main/java/uk/gov/justice/subscription/jms/core/JmsUriToDestinationTypeConverter.java
@@ -1,0 +1,58 @@
+package uk.gov.justice.subscription.jms.core;
+
+import static org.apache.commons.lang3.StringUtils.trimToEmpty;
+import static uk.gov.justice.services.core.annotation.Component.EVENT_PROCESSOR;
+
+import java.util.Optional;
+
+import javax.jms.Destination;
+import javax.jms.Queue;
+import javax.jms.Topic;
+
+
+public class JmsUriToDestinationTypeConverter {
+
+    private static final String QUEUE = "queue";
+    private static final String TOPIC = "topic";
+
+    /**
+     * Retrieves the destination from jmsUri in the format jms:queue:some-more-string
+     *
+     * @return Optional of Queue.class, Topic.class or null
+     */
+    Optional<Class<? extends Destination>> convert(final String jmsUri) {
+
+        final String[] parts = trimToEmpty(jmsUri).split(":");
+        final String destinationType = (parts.length > 1) ? parts[1] : null;
+
+        if (QUEUE.equalsIgnoreCase(destinationType)) {
+            return Optional.of(Queue.class);
+        }
+
+        if (TOPIC.equalsIgnoreCase(destinationType)) {
+            return Optional.of(Topic.class);
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * EVENT_PROCESSOR.
+     * For any other component, return null
+     *
+     * @param serviceComponent EVENT_PROCESSOR, EVENT_LISTENER, etc
+     * @param jmsUri           a fully blown jms URI
+     * @return a destination type by calling convert() only if the component type is an EVENT_PROCESSOR
+     */
+    public Optional<Class<? extends Destination>> convertForEventProcessor(final String serviceComponent, final String jmsUri) {
+        if (isEventProcessor(serviceComponent)) {
+            return convert(jmsUri);
+        }
+
+        return Optional.empty();
+    }
+
+    public boolean isEventProcessor(final String serviceComponent) {
+        return (serviceComponent != null && serviceComponent.contains(EVENT_PROCESSOR));
+    }
+}

--- a/framework-generators/messaging-adapter-generator/src/test/java/uk/gov/justice/raml/jms/core/EventSourcesDestinationTypeFinderFactoryTest.java
+++ b/framework-generators/messaging-adapter-generator/src/test/java/uk/gov/justice/raml/jms/core/EventSourcesDestinationTypeFinderFactoryTest.java
@@ -1,0 +1,17 @@
+package uk.gov.justice.raml.jms.core;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import org.junit.jupiter.api.Test;
+
+class EventSourcesDestinationTypeFinderFactoryTest {
+
+    private final EventSourcesDestinationTypeFinderFactory factory = new EventSourcesDestinationTypeFinderFactory();
+
+    @Test
+    void shouldCreate() {
+        assertThat(factory.create(), is(notNullValue()));
+    }
+}

--- a/framework-generators/messaging-adapter-generator/src/test/java/uk/gov/justice/raml/jms/core/EventSourcesDestinationTypeFinderTest.java
+++ b/framework-generators/messaging-adapter-generator/src/test/java/uk/gov/justice/raml/jms/core/EventSourcesDestinationTypeFinderTest.java
@@ -1,0 +1,127 @@
+package uk.gov.justice.raml.jms.core;
+
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.justice.services.core.annotation.Component.EVENT_LISTENER;
+import static uk.gov.justice.services.core.annotation.Component.EVENT_PROCESSOR;
+
+import uk.gov.justice.services.generators.subscription.parser.EventSourcesFileParserFactory;
+import uk.gov.justice.services.generators.subscription.parser.JmsUriToDestinationConverter;
+import uk.gov.justice.subscription.jms.core.JmsUriToDestinationTypeConverter;
+
+import java.util.Optional;
+
+import javax.jms.Destination;
+import javax.jms.Queue;
+import javax.jms.Topic;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+
+@ExtendWith(MockitoExtension.class)
+class EventSourcesDestinationTypeFinderTest {
+
+    @Mock
+    private Logger logger;
+    @Spy
+    private JmsUriToDestinationTypeConverter uriToDestinationTypeConverter;
+    @Spy
+    private JmsUriToDestinationConverter jmsUriToDestinationConverter;
+    @Spy
+    private EventSourcesFileParserFactory eventSourceYamlParserFactory;
+
+
+    @InjectMocks
+    private EventSourcesDestinationTypeFinder destinationTypeFinder;
+
+    @Test
+    void shouldFindDestinationTypeForEventProcessorDefinedAsTopic() {
+        final Optional<Class<? extends Destination>> res = destinationTypeFinder.findForEventProcessor(EVENT_PROCESSOR, "structure.event");
+
+        assertThat(res, is(of(Topic.class)));
+    }
+
+    @Test
+    void shouldFindDestinationTypeForEventProcessorDefinedAsQueue() {
+        final Optional<Class<? extends Destination>> res = destinationTypeFinder.findForEventProcessor(EVENT_PROCESSOR, "queuestructure.event");
+
+        assertThat(res, is(of(Queue.class)));
+    }
+
+    @Test
+    void shouldFindDestinationTypeForEventProcessorDefinedAsEmptyWhenException() {
+
+        when(uriToDestinationTypeConverter.convertForEventProcessor(anyString(), anyString())).
+                thenThrow(new NullPointerException("Could not find any event-sources.yaml file"));
+
+        final Optional<Class<? extends Destination>> res = destinationTypeFinder.findForEventProcessor(EVENT_PROCESSOR, "queuestructure.event");
+
+        assertThat(res, is(empty()));
+        verify(logger).
+                warn("Failed in findForEventProcessor: {}", "Could not find any event-sources.yaml file");
+
+        verifyNoMoreInteractions(logger);
+    }
+
+
+    @Test
+    void shouldFindDestinationTypeForEventProcessorAsEmptyWhenComponentIsEventListener() {
+        final Optional<Class<? extends Destination>> res = destinationTypeFinder.findForEventProcessor(EVENT_LISTENER, "structure.event");
+
+        assertThat(res, is(empty()));
+    }
+
+    @Test
+    void shouldFindDestinationTypeForEventProcessorAsEmptyWhenComponentIsUnknown() {
+        final Optional<Class<? extends Destination>> res = destinationTypeFinder.findForEventProcessor("unknown-component", "structure.event");
+
+        assertThat(res, is(empty()));
+    }
+
+    @Test
+    void shouldFindDestinationTypeForEventProcessorAsEmptyWhenComponentAndDestinationAreNull() {
+        final Optional<Class<? extends Destination>> res = destinationTypeFinder.findForEventProcessor(null, null);
+
+        assertThat(res, is(empty()));
+    }
+
+    @Test
+    void shouldFindDestinationTypeForEventProcessorAsEmptyWhenComponentIsNull() {
+        final Optional<Class<? extends Destination>> res = destinationTypeFinder.findForEventProcessor(null, "some-destination");
+
+        assertThat(res, is(empty()));
+    }
+
+    @Test
+    void shouldFindDestinationTypeForEventProcessorAsEmptyWhenComponentIsEmpty() {
+        final Optional<Class<? extends Destination>> res = destinationTypeFinder.findForEventProcessor(" ", "some-destination");
+
+        assertThat(res, is(empty()));
+    }
+
+
+    @Test
+    void shouldFindDestinationTypeForEventProcessorAsEmptyWhenDestinationIsNull() {
+        final Optional<Class<? extends Destination>> res = destinationTypeFinder.findForEventProcessor(EVENT_PROCESSOR, null);
+
+        assertThat(res, is(empty()));
+    }
+
+    @Test
+    void shouldFindDestinationTypeForEventProcessorAsEmptyWhenDestinationIsEmptyl() {
+        final Optional<Class<? extends Destination>> res = destinationTypeFinder.findForEventProcessor(EVENT_PROCESSOR, "");
+
+        assertThat(res, is(empty()));
+    }
+}

--- a/framework-generators/messaging-adapter-generator/src/test/java/uk/gov/justice/raml/jms/core/MessageListenerCodeGeneratorTest.java
+++ b/framework-generators/messaging-adapter-generator/src/test/java/uk/gov/justice/raml/jms/core/MessageListenerCodeGeneratorTest.java
@@ -1,0 +1,127 @@
+package uk.gov.justice.raml.jms.core;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import uk.gov.justice.maven.generator.io.files.parser.core.GeneratorProperties;
+import uk.gov.justice.raml.jms.config.GeneratorPropertiesFactory;
+import uk.gov.justice.services.generators.commons.config.CommonGeneratorProperties;
+import uk.gov.justice.services.generators.commons.helper.MessagingAdapterBaseUri;
+import uk.gov.justice.services.generators.commons.helper.MessagingResourceUri;
+import uk.gov.justice.services.generators.test.utils.builder.ResourceBuilder;
+
+import com.squareup.javapoet.TypeSpec;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.raml.model.Resource;
+
+@ExtendWith(MockitoExtension.class)
+public class MessageListenerCodeGeneratorTest {
+
+    @InjectMocks
+    private MessageListenerCodeGenerator messageListenerCodeGenerator;
+
+    @Test
+    public void shouldGenerateMDBForEventProcessorAsQueue() {
+
+        final TypeSpec typeSpec = getTypeSpecForEventProcessor("/queuestructure.event");
+
+        assertThat(typeSpec.toString(), is("""
+                @uk.gov.justice.services.core.annotation.Adapter("EVENT_PROCESSOR")
+                @javax.ejb.MessageDriven(
+                    activationConfig = {
+                        @javax.ejb.ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"),
+                        @javax.ejb.ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = "queuestructure.event"),
+                        @javax.ejb.ActivationConfigProperty(propertyName = "shareSubscriptions", propertyValue = "true"),
+                        @javax.ejb.ActivationConfigProperty(propertyName = "messageSelector", propertyValue = "CPPNAME in('ctx.command.defcmd')"),
+                        @javax.ejb.ActivationConfigProperty(propertyName = "maxSession", propertyValue = "${property.mdb.EVENT_PROCESSOR.maxSession:15}")
+                    }
+                )
+                @javax.interceptor.Interceptors({
+                    uk.gov.moj.base.package.name.Service2EventProcessorMessagingResourceUriJmsLoggerMetadataInterceptor.class,
+                    uk.gov.justice.services.adapter.messaging.JsonSchemaValidationInterceptor.class
+                })
+                public class Service2EventProcessorMessagingResourceUriJmsListener implements javax.jms.MessageListener {
+                  private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(uk.gov.moj.base.package.name.Service2EventProcessorMessagingResourceUriJmsListener.class);
+                                
+                  @javax.inject.Inject
+                  uk.gov.justice.services.core.interceptor.InterceptorChainProcessor interceptorChainProcessor;
+                                
+                  @javax.inject.Inject
+                  uk.gov.justice.services.adapter.messaging.JmsProcessor jmsProcessor;
+                                
+                  @java.lang.Override
+                  public void onMessage(javax.jms.Message message) {
+                    uk.gov.justice.services.messaging.logging.LoggerUtils.trace(LOGGER, () -> "Received JMS message");
+                    jmsProcessor.process(interceptorChainProcessor::process, message);
+                  }
+                }
+                """));
+    }
+
+    @Test
+    public void shouldGenerateMDBForEventProcessorAsTopic() {
+
+        final TypeSpec typeSpec = getTypeSpecForEventProcessor("");
+
+        assertThat(typeSpec.toString(), is("""
+                @uk.gov.justice.services.core.annotation.Adapter("EVENT_PROCESSOR")
+                @javax.ejb.MessageDriven(
+                    activationConfig = {
+                        @javax.ejb.ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Topic"),
+                        @javax.ejb.ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = "somecontext.controller.command"),
+                        @javax.ejb.ActivationConfigProperty(propertyName = "shareSubscriptions", propertyValue = "true"),
+                        @javax.ejb.ActivationConfigProperty(propertyName = "messageSelector", propertyValue = "CPPNAME in('ctx.command.defcmd')"),
+                        @javax.ejb.ActivationConfigProperty(propertyName = "subscriptionDurability", propertyValue = "Durable"),
+                        @javax.ejb.ActivationConfigProperty(propertyName = "subscriptionName", propertyValue = "service2.event.processor.somecontext.controller.command"),
+                        @javax.ejb.ActivationConfigProperty(propertyName = "maxSession", propertyValue = "${property.mdb.EVENT_PROCESSOR.maxSession:15}")
+                    }
+                )
+                @javax.interceptor.Interceptors({
+                    uk.gov.moj.base.package.name.Service2EventProcessorMessagingResourceUriJmsLoggerMetadataInterceptor.class,
+                    uk.gov.justice.services.adapter.messaging.JsonSchemaValidationInterceptor.class
+                })
+                public class Service2EventProcessorMessagingResourceUriJmsListener implements javax.jms.MessageListener {
+                  private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(uk.gov.moj.base.package.name.Service2EventProcessorMessagingResourceUriJmsListener.class);
+                            
+                  @javax.inject.Inject
+                  uk.gov.justice.services.core.interceptor.InterceptorChainProcessor interceptorChainProcessor;
+                            
+                  @javax.inject.Inject
+                  uk.gov.justice.services.adapter.messaging.JmsProcessor jmsProcessor;
+                            
+                  @java.lang.Override
+                  public void onMessage(javax.jms.Message message) {
+                    uk.gov.justice.services.messaging.logging.LoggerUtils.trace(LOGGER, () -> "Received JMS message");
+                    jmsProcessor.process(interceptorChainProcessor::process, message);
+                  }
+                }
+                """));
+    }
+
+    private TypeSpec getTypeSpecForEventProcessor(final String ramlResourceUri) {
+        final String basePackageName = "uk.gov.moj.base.package.name";
+
+        ResourceBuilder resourceBuilder = ResourceBuilder.resource().withDefaultPostAction();
+        if (!isBlank(ramlResourceUri)) {
+            resourceBuilder = resourceBuilder.withRelativeUri(ramlResourceUri);
+        }
+
+        final Resource resource = resourceBuilder.build();
+
+        final MessagingAdapterBaseUri messagingAdapterBaseUri = new MessagingAdapterBaseUri("message://event/processor/message/service2");
+        final MessagingResourceUri messagingResourceUri = new MessagingResourceUri("messagingResourceUri");
+        final uk.gov.justice.raml.jms.core.ClassNameFactory classNameFactory = new ClassNameFactory(
+                messagingAdapterBaseUri,
+                messagingResourceUri,
+                basePackageName);
+
+        final GeneratorProperties generatorProperties = new GeneratorPropertiesFactory().withServiceComponentOf("EVENT_PROCESSOR");
+
+
+        return messageListenerCodeGenerator.generate(resource, messagingAdapterBaseUri, (CommonGeneratorProperties) generatorProperties, classNameFactory);
+    }
+}

--- a/framework-generators/messaging-adapter-generator/src/test/java/uk/gov/justice/subscription/jms/core/JmsUriToDestinationTypeConverterTest.java
+++ b/framework-generators/messaging-adapter-generator/src/test/java/uk/gov/justice/subscription/jms/core/JmsUriToDestinationTypeConverterTest.java
@@ -1,0 +1,117 @@
+package uk.gov.justice.subscription.jms.core;
+
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.justice.services.core.annotation.Component.EVENT_LISTENER;
+import static uk.gov.justice.services.core.annotation.Component.EVENT_PROCESSOR;
+
+import java.util.Optional;
+
+import javax.jms.Destination;
+import javax.jms.Queue;
+import javax.jms.Topic;
+
+import org.junit.jupiter.api.Test;
+
+class JmsUriToDestinationTypeConverterTest {
+
+    private JmsUriToDestinationTypeConverter jmsUriToDestinationTypeConverter = new JmsUriToDestinationTypeConverter();
+
+    @Test
+    public void shouldConvertJmsTopicUriToDestinationType() {
+
+        final Optional<Class<? extends Destination>> destinationType = jmsUriToDestinationTypeConverter.convert("jms:topic:public.event");
+
+        assertThat(destinationType, is(of(Topic.class)));
+    }
+
+    @Test
+    public void shouldConvertJmsTopicUriToDestinationTypeCaseInsensitive() {
+
+        final Optional<Class<? extends Destination>> destinationType = jmsUriToDestinationTypeConverter.convert("jms:toPIc:public.event");
+
+        assertThat(destinationType, is(of(Topic.class)));
+    }
+
+    @Test
+    public void shouldConvertJmsQueueUriToDestinationType() {
+
+        final Optional<Class<? extends Destination>> destinationType = jmsUriToDestinationTypeConverter.convert("jms:queue:command.handler");
+
+        assertThat(destinationType, is(of(Queue.class)));
+    }
+
+    @Test
+    public void shouldConvertJmsQueueUriToDestinationTypeCaseInsensitive() {
+
+        final Optional<Class<? extends Destination>> destinationType = jmsUriToDestinationTypeConverter.convert("jms:quEUe:command.handler");
+
+        assertThat(destinationType, is(of(Queue.class)));
+    }
+
+    @Test
+    public void shouldConvertJmsInvalidUriToDestinationTypeEmpty() {
+
+        final Optional<Class<? extends Destination>> destinationType = jmsUriToDestinationTypeConverter.convert("jms:xxqueue:command.handler");
+
+        assertThat(destinationType, is(empty()));
+    }
+
+    @Test
+    public void shouldConvertHelloJmsdUriToDestinationTypeEmpty() {
+
+        final Optional<Class<? extends Destination>> destinationType  = jmsUriToDestinationTypeConverter.convert("hello");
+
+        assertThat(destinationType, is(empty()));
+    }
+
+    @Test
+    public void shouldConvertEmptyJmsdUriToDestinationTypeEmpty() {
+
+        final Optional<Class<? extends Destination>> destinationType = jmsUriToDestinationTypeConverter.convert("");
+
+        assertThat(destinationType, is(empty()));
+    }
+
+    @Test
+    public void shouldConvertNullJmsdUriToDestinationTypeEmpty() {
+
+        final Optional<Class<? extends Destination>> destinationType  = jmsUriToDestinationTypeConverter.convert(null);
+
+        assertThat(destinationType, is(empty()));
+    }
+
+    @Test
+    public void shouldConvertJmsTopicInPositionZeroToDestinationTypeEmpty() {
+
+        final Optional<Class<? extends Destination>> destinationType = jmsUriToDestinationTypeConverter.convert("topic:jms:public.event");
+
+        assertThat(destinationType, is(empty()));
+    }
+
+    @Test
+    public void shouldConvertJmsTopicInPositionTwoToDestinationTypeEmpty() {
+
+        final Optional<Class<? extends Destination>> destinationType = jmsUriToDestinationTypeConverter.convert("jms:alpha:topic:public.event");
+
+        assertThat(destinationType, is(empty()));
+    }
+
+    @Test
+    public void shouldConvertForEventProcessor() {
+
+        final Optional<Class<? extends Destination>> destinationType  = jmsUriToDestinationTypeConverter.convertForEventProcessor(EVENT_PROCESSOR, "jms:topic:public.event");
+
+        assertThat(destinationType, is(of(Topic.class)));
+    }
+
+    @Test
+    public void shouldNotConvertForEventProcessorIfComponentIsEventListener() {
+
+        final Optional<Class<? extends Destination>> destinationType = jmsUriToDestinationTypeConverter.convertForEventProcessor(EVENT_LISTENER, "jms:topic:public.event");
+
+        assertThat(destinationType, is(empty()));
+    }
+}

--- a/framework-generators/messaging-adapter-generator/src/test/resources/yaml/event-sources.yaml
+++ b/framework-generators/messaging-adapter-generator/src/test/resources/yaml/event-sources.yaml
@@ -28,3 +28,8 @@ event_sources:
   location:
     jms_uri:  jms:topic:structure.event
     rest_uri: http://localhost:8080/example/event-source-api/rest
+
+- name: queuestructure.event.processor.service
+  location:
+    jms_uri:  jms:queue:queuestructure.event
+    rest_uri: http://localhost:8080/example/event-source-api/rest


### PR DESCRIPTION
…vent_sources.location.jms_uri in event-sources.yaml when RAML is used for the EVENT_PROCESSOR